### PR TITLE
Polish Navbar Controls Behavior

### DIFF
--- a/frontend/apps/frontend/src/app/core/nav-bar.service.ts
+++ b/frontend/apps/frontend/src/app/core/nav-bar.service.ts
@@ -1,7 +1,7 @@
-import { Injectable } from "@angular/core";
-import { BehaviorSubject, Subject } from "rxjs";
-import { ActivePlugin } from "../shared/classes/activePlugin";
-import { Router } from "@angular/router";
+import {Injectable} from "@angular/core";
+import {BehaviorSubject, Subject} from "rxjs";
+import {ActivePlugin} from "../shared/classes/activePlugin";
+import {Router} from "@angular/router";
 
 @Injectable({
   providedIn: "root",
@@ -9,7 +9,6 @@ import { Router } from "@angular/router";
 export class NavBarService {
   openPlugins = new Subject<ActivePlugin[]>();
   isListShown = new BehaviorSubject<boolean>(false);
-  areSettingsShown = new BehaviorSubject<boolean>(false);
   private _openPlugins: ActivePlugin[] = [
     new ActivePlugin("home", "Home", true),
   ];
@@ -46,10 +45,6 @@ export class NavBarService {
 
   toggleIsListShown(val: boolean) {
     this.isListShown.next(val);
-  }
-
-  toggleAreSettingsShown() {
-    this.areSettingsShown.next(!this.areSettingsShown.getValue());
   }
 
   openSettings() {

--- a/frontend/apps/frontend/src/app/shared/nav-bar/nav-bar.component.html
+++ b/frontend/apps/frontend/src/app/shared/nav-bar/nav-bar.component.html
@@ -11,7 +11,7 @@
     </ul>
   </div>
 
-  <div class="flex flex-row items-center gap-2 h-full"  *ngIf="!settingsShown">
+  <div class="flex flex-row items-center gap-2 h-full"  *ngIf="showControls">
     <syno-icon-button (click)="searchClicked()">
       <i-tabler name="search" class="navbar-icon-scale"/>
     </syno-icon-button>

--- a/frontend/apps/frontend/src/app/shared/nav-bar/nav-bar.component.ts
+++ b/frontend/apps/frontend/src/app/shared/nav-bar/nav-bar.component.ts
@@ -1,7 +1,7 @@
-import { ChangeDetectorRef, Component, OnInit } from "@angular/core";
-import { ActivePlugin } from "../classes/activePlugin";
-import { NavBarService } from "../../core/nav-bar.service";
-import { SearchService } from "../../core/search.service";
+import {ChangeDetectorRef, Component, OnInit} from "@angular/core";
+import {ActivePlugin} from "../classes/activePlugin";
+import {NavBarService} from "../../core/nav-bar.service";
+import {SearchService} from "../../core/search.service";
 
 @Component({
   selector: "app-nav-bar",
@@ -12,13 +12,14 @@ export class NavBarComponent implements OnInit {
   tabs: ActivePlugin[] = [];
   public val: string = "";
   viewList: boolean = false;
-  settingsShown: boolean = false;
+  showControls: boolean = true;
 
   constructor(
     private navService: NavBarService,
     private changeDetection: ChangeDetectorRef,
     private searchService: SearchService
-  ) {}
+  ) {
+  }
 
   ngOnInit(): void {
     this.val = "nav";
@@ -31,18 +32,17 @@ export class NavBarComponent implements OnInit {
     });
     this.navService.getPlugins();
     this.navService.isListShown.subscribe((x) => this.viewList = x);
-    this.navService.areSettingsShown.subscribe((x) => this.settingsShown = x);
     this.showPlugin(this.tabs.find(tab => tab.active));
   }
 
   closeTabClick(plugin: ActivePlugin) {
     this.navService.closePlugin(plugin.id);
-    this.navService.activatePlugin("home");
-    if (plugin.id === "settings") this.navService.toggleAreSettingsShown();
+    this.showPlugin(this.tabs.find(t => t.id === "home"));
   }
 
   showPlugin(plugin: ActivePlugin | undefined): void {
     if (plugin) this.navService.activatePlugin(plugin.id);
+    this.showControls = plugin?.id !== "settings";
   }
 
   searchClicked() {
@@ -55,6 +55,6 @@ export class NavBarComponent implements OnInit {
 
   showSettings() {
     this.navService.openSettings();
-    this.navService.toggleAreSettingsShown();
+    this.showControls = false;
   }
 }


### PR DESCRIPTION
Zerst woas so, dass der Ansicht-Switch und Such-Button und so a ausblendt woan san, wonn d Settings nur im Hintergrund offn woan, wos eher unguad is. Jetzt wern de Controls nur ausblendt, wonn a wirklich da Settings-Tab aktiv is.

Meiner Meinung noch muass des eig a ned üba an Service laufen weil des a Navbar-interne Gschicht is (i woaß, dass i da des so ongschofft hob @TaWi04, duad ma load haha).

closes #359 